### PR TITLE
Bugfixed resize to correctly resize predictions 

### DIFF
--- a/src/ModelYOLO.cpp
+++ b/src/ModelYOLO.cpp
@@ -225,7 +225,7 @@ cv::Mat ModelYOLO::formatToSquare(const cv::Mat& source)
 
     if (max < mInputSideLength) {
         cv::Mat output = cv::Mat::zeros(mInputSideLength, mInputSideLength, CV_8UC3);
-        resize(source, output, mInputShape);
+        source.copyTo(output(cv::Rect(0, 0, col, row)));
         return output;
     }
 


### PR DESCRIPTION
Bugfixed resize to correctly resize predictions. Now smaller input sizes are handled correctly.